### PR TITLE
chore: change of ownership from developer-productivity to sre

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -12,4 +12,4 @@ metadata:
 spec:
   type: other
   lifecycle: production
-  owner: developer-productivity
+  owner: sre


### PR DESCRIPTION
This PR changes the ownership of this repo to SRE, as the developer productivity team doesn't exist anymore.